### PR TITLE
fix: avoid double 'v' in release notes heading

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
 
           # Generate release notes
           cat << EOF > release_notes.md
-          # SwiftZlib v$VERSION
+          # SwiftZlib ${VERSION}
 
           ## What's Changed
 
@@ -77,11 +77,11 @@ jobs:
 
           ## Installation
 
-          \`\`\`swift
+          ```swift
           dependencies: [
               .package(url: "https://github.com/Kosikowski/swift-zlib.git", from: "$VERSION")
           ]
-          \`\`\`
+          ```
 
           ## Breaking Changes
 
@@ -89,9 +89,9 @@ jobs:
 
           ## Recent Commits
 
-          \`\`\`
+          ```
           $COMMITS
-          \`\`\`
+          ```
           EOF
 
           echo "notes<<EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,11 +77,11 @@ jobs:
 
           ## Installation
 
-          ```swift
+          \`\`\`swift
           dependencies: [
               .package(url: "https://github.com/Kosikowski/swift-zlib.git", from: "$VERSION")
           ]
-          ```
+          \`\`\`
 
           ## Breaking Changes
 
@@ -89,9 +89,9 @@ jobs:
 
           ## Recent Commits
 
-          ```
+          \`\`\`
           $COMMITS
-          ```
+          \`\`\`
           EOF
 
           echo "notes<<EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem
The release notes heading was showing "SwiftZlib vv0.0.1" (double 'v') because the template used `# SwiftZlib v$VERSION` where `$VERSION` already contains the 'v' prefix from the tag.

## Solution
- Changed the release notes heading from `# SwiftZlib v$VERSION` to `# SwiftZlib ${VERSION}`
- This ensures the heading shows "SwiftZlib v0.0.1" (single 'v') instead of "SwiftZlib vv0.0.1"
- Restored full release notes template and workflow logic
- No other content was removed or altered

## Testing
- The change only affects the release notes heading
- Future releases will have correctly formatted headings
- All other release functionality remains unchanged

## Before
```
# SwiftZlib vv0.0.1  (double 'v')
```

## After
```
# SwiftZlib v0.0.1   (single 'v')
```

Fixes the cosmetic issue where release notes headings showed double 'v' characters. 